### PR TITLE
Multi WiiM device capable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note: The WiiM device has a self-signed certificate, which is deemed unsafe by a
    or download the ZIP file and unpack to a folder
 2. Do an ```npm install``` to install the required packages
 3. Copy the ```config-sample.yaml``` file to ```config.yaml```
-4. Edit ```config.yaml``` in your favorite text editor and replace the IP-address with the address of your WiiM device.  
+4. Edit ```config.yaml``` in your favorite text editor and replace the IP-address(es) with the actual ip address(es) of your WiiM device(s).  
    > You can find your IP-address in the WiiM Home app > Devices > Settings > Network Status
 5. Run ```node .\index.js```
 6. You will find the interactive documentation at <http://localhost:3000/>

--- a/_test.txt
+++ b/_test.txt
@@ -1,1 +1,0 @@
-On main branch

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -1,6 +1,14 @@
-deviceHost: 
-  10.10.10.254
-description:  >+
-  Make a copy of this file and rename it to config.yaml. 
-  Replace deviceHost with the IP address of your device.
-  The IP address of the device can be found in the device's settings.
+deviceHosts:
+  - name: My WiiM Device
+    ip: 10.10.10.254
+
+description: >+
+  Make a copy of this file and rename it to config.yaml.
+  Replace `deviceHosts` with an array of objects. 
+  Each object should contain a `name` and an `ip` field. 
+  Example of multiple devices:
+    - name: WiiM Device A
+      ip: 10.10.10.125
+    - name: WiiM Device B
+      ip: 10.10.10.127
+  The IP address of the device can be found in the device's settings > network status.

--- a/index.js
+++ b/index.js
@@ -12,9 +12,26 @@ const https = require("https");
 const config = YAML.load("config.yaml");
 const swaggerDocument = YAML.load("openapi.yaml");
 
+// Normalize device list from config and log configured device hosts
+const devices = config.deviceHosts || [];
+console.log("The following devices have been configured for the proxy:");
+devices.forEach((device, idx) => {
+  console.log(`  [${idx}] ${device.name}: ${device.ip}`);
+});
+
 // Create express app on port 3000
 const app = express();
 const port = 3000;
+
+// Inject device-specific servers into the OpenAPI document so Swagger UI
+// shows a server entry for each configured device. Each server points at our
+// local proxy and passes a `device` parameter with the device index.
+if (Array.isArray(devices) && devices.length > 0) {
+  swaggerDocument.servers = devices.map((d, i) => ({
+    url: `http://localhost:${port}/proxy/${i}`,
+    description: `${d.name} (${d.ip})`
+  }));
+}
 
 // Redirect root to /api-docs
 app.get("/", (req, res) => {
@@ -34,15 +51,28 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument, options))
 
 // Proxy requests to WiiM/Linkplay device
 app.use("/proxy", (req, res) => {
-  // Translate the /proxy uri to the corresponding /httpapi.asp?command=
-  let reqUrl = req.url;
-  reqUrl = reqUrl.replace("/", "/httpapi.asp?command=");
-  console.log("Call:", "https://" + config.deviceHost + reqUrl);
 
-  // Create a new HTTP client to forward the request to the WiiM/Linkplay device
-  const http_client = https.request({
-    host: config.deviceHost,
-    path: reqUrl,
+  // Translate the /proxy uri to the corresponding device and /httpapi.asp?command=
+  // Since req.url is in the format /{idx}}/{command}, we need to split the index and command
+  // The index will resolve to the device to target
+  // The command will be passed to the device unaltered
+  let reqUrl = req.url;
+  const targetIndex = reqUrl.split("/")[1];
+  const commandPath = "/httpapi.asp?command=" + reqUrl.split("/").slice(2).join("/");
+
+  // Determine which device to target based on the selected server; default to index 0.
+  const deviceIndex = Number.isFinite(Number(targetIndex)) ? Number(targetIndex) : 0;
+  const target = devices[deviceIndex] || devices[0];
+  if (!target) {
+    return res.status(500).send("No device configured");
+  }
+
+  console.log("Call [" + target.name + "]:", "https://" + target.ip + commandPath);
+
+  // Create a new HTTPS client to forward the request to the WiiM/Linkplay device
+  const https_client = https.request({
+    host: target.ip,
+    path: commandPath,
     method: req.method,
     rejectUnauthorized: false, // Ignore self-signed certificate
     headers: req.headers,
@@ -54,8 +84,8 @@ app.use("/proxy", (req, res) => {
   });
 
   // Forward the body of the request to the WiiM/Linkplay device
-  req.pipe(http_client);
-  
+  req.pipe(https_client);
+
 });
 
 app.listen(port, () => {

--- a/openapi.json
+++ b/openapi.json
@@ -9,7 +9,7 @@
   "servers": [
     {
       "url": "http://localhost:3000/proxy",
-      "description": "Reverse proxy to access the device. See the README for more information."
+      "description": "Reverse proxy to access the device. The actual devices are set using config.yaml. Please see the README for more information."
     }
   ],
   "tags": [

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,7 +29,7 @@ info:
 
 servers:
   - url: "http://localhost:3000/proxy"
-    description: Reverse proxy to access the device. See the README for more information.
+    description: Reverse proxy to access the device. The actual devices are set using config.yaml. Please see the README for more information.
 
 tags:
   - name: Generic


### PR DESCRIPTION
## 🧾 Summary

Added the option to add more than one WiiM device to be proxied. 
Update your config.yaml in order to add multiple devices, if you have more than one.
A device name and an IP address are required. When using the Swagger UI you can now easily switch between devices.

## 🔧 Type of change

- [X] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Chore (deps, refactor)
- [X] Documentation

## ✔️ What was done?

- Changed config.yaml, see config-sample.yaml
- Swagger UI now aware of multiple devices
- Proxy handles the requested WiiM device you want to examine

## 🧪 Test information

Manual testing

## 📸 Screenshots (optional)

N/A

## ⛓️ Related issues

N/A
