### PR TITLE
republish of docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -6,12 +6,47 @@ export default defineConfig({
 
   ignoreDeadLinks: true,
   base: '/wiim-httpapi/',
+  lastUpdated: true,
+
+  head: [
+    [
+      'meta',
+      { name: 'google-site-verification', content: 'yPm8E8x36ekuDpChm-70rwUF5w-_-XcmH72Lf_OuXQM' }
+    ],
+    [
+      'script',
+      { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-Q2V26LJJ2D' }
+    ],
+    [
+      'script',
+      {},
+      `window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-Q2V26LJJ2D');`
+    ]
+  ],
+
+  sitemap: {
+    hostname: 'https://cvdlinden.github.io/wiim-httpapi/'
+  },
 
   themeConfig: {
+
+    search: {
+      provider: 'local'
+    },
+
     nav: [
       { text: 'Home', link: '/' },
       { text: 'API Reference', link: '/api-reference' }
     ],
+
+    footer: {
+      message: 'Released under the <a href="https://github.com/cvdlinden/wiim-httpapi/blob/main/LICENSE">GNU General Public License v3.0</a>.',
+      copyright: 'Copyright © 2026-present, <a href="https://github.com/cvdlinden/wiim-httpapi">WiiM HTTP API</a>'
+    },
+
     sidebar: [
       {
         text: 'Getting Started',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wiim-httpapi",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wiim-httpapi",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiim-httpapi",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Exploring the HTTP API for WiiM products. Work in progress...",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 🧾 Summary

Republish of documents at https://cvdlinden.github.io/wiim-httpapi/

## 🔧 Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Hotfix
- [x] Chore (deps, refactor)
- [x] Documentation

## ✔️ What was done?

- Republished documentation at https://cvdlinden.github.io/wiim-httpapi/
- Made publishing action work again
- Added Google verification for SEO

## 🧪 Test information

Manual

## 📸 Screenshots (optional)

N/A

## ⛓️ Related issues

N/A
