### PR TITLE
Tooling to generate local self contained HTML and PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Rendered docs (scripts/render-docs.sh)
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# WiiM HTTP API docs — build helpers.
+#
+#   make check   validate openapi.yaml (parse + duplicate-key detection)
+#   make html    render a readable single-file HTML (Redoc)
+#   make pdf      render HTML + PDF (Redoc + headless Chrome)
+#   make json     regenerate openapi.json from openapi.yaml
+#   make clean    remove build/ output
+#
+# Rendering needs npx (bundled with npm); the PDF step additionally needs a
+# Chromium/Chrome binary. Each target checks for what it needs and prints a
+# clear message if a tool is missing.
+
+SPEC := openapi.yaml
+
+.PHONY: check html pdf json clean help
+
+help:
+	@echo "targets: check | html | pdf | json | clean"
+
+# --- validation --------------------------------------------------------
+# Prefer python3; fall back to python. validate-spec.py rejects duplicate
+# mapping keys (which PyYAML otherwise silently accepts but Redoc rejects).
+check:
+	@PY=$$(command -v python3 || command -v python); \
+	if [ -z "$$PY" ]; then \
+		echo "ERROR: python3 not found (needed for 'make check')." >&2; exit 1; \
+	fi; \
+	"$$PY" scripts/validate-spec.py $(SPEC)
+
+# --- rendering ---------------------------------------------------------
+# HTML/PDF both validate first, then shell out to the render script.
+html: check
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make html'." >&2; exit 1; }
+	@./scripts/render-docs.sh --html
+
+pdf: check
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make pdf'." >&2; exit 1; }
+	@if ! command -v google-chrome-stable >/dev/null 2>&1 \
+	    && ! command -v google-chrome >/dev/null 2>&1 \
+	    && ! command -v chromium >/dev/null 2>&1 \
+	    && ! command -v chromium-browser >/dev/null 2>&1; then \
+		echo "WARNING: no Chrome/Chromium found; only HTML will be produced." >&2; \
+	fi
+	@./scripts/render-docs.sh
+
+# --- generated json ----------------------------------------------------
+json:
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make json'." >&2; exit 1; }
+	@npx --yes js-yaml $(SPEC) > openapi.json && echo ">> wrote openapi.json"
+
+clean:
+	@rm -rf build && echo ">> removed build/"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 # WiiM HTTP API docs — build helpers.
 #
-#   make check   validate openapi.yaml (parse + duplicate-key detection)
-#   make html    render a readable single-file HTML (Redoc)
-#   make pdf      render HTML + PDF (Redoc + headless Chrome)
-#   make json     regenerate openapi.json from openapi.yaml
-#   make clean    remove build/ output
+#   make check                 validate openapi.yaml (parse + duplicate-key detection)
+#   make html                  render a readable single-file HTML (Redoc)
+#   make pdf                   render HTML + PDF (Redoc + headless Chrome/Firefox)
+#   make pdf ENGINE=firefox    force Firefox for the PDF step (default: auto)
+#   make json                  regenerate openapi.json from openapi.yaml
+#   make clean                 remove build/ output
 #
 # Rendering needs npx (bundled with npm); the PDF step additionally needs a
-# Chromium/Chrome binary. Each target checks for what it needs and prints a
-# clear message if a tool is missing.
+# Chromium/Chrome or Firefox binary. Each target checks for what it needs and
+# prints a clear message if a tool is missing.
 
 SPEC := openapi.yaml
+ENGINE := auto
 
 .PHONY: check html pdf json clean help
 
@@ -40,10 +42,12 @@ pdf: check
 	@if ! command -v google-chrome-stable >/dev/null 2>&1 \
 	    && ! command -v google-chrome >/dev/null 2>&1 \
 	    && ! command -v chromium >/dev/null 2>&1 \
-	    && ! command -v chromium-browser >/dev/null 2>&1; then \
-		echo "WARNING: no Chrome/Chromium found; only HTML will be produced." >&2; \
+	    && ! command -v chromium-browser >/dev/null 2>&1 \
+	    && ! command -v firefox >/dev/null 2>&1 \
+	    && ! command -v firefox-esr >/dev/null 2>&1; then \
+		echo "WARNING: no Chrome/Chromium/Firefox found; only HTML will be produced." >&2; \
 	fi
-	@./scripts/render-docs.sh
+	@./scripts/render-docs.sh --engine=$(ENGINE)
 
 # --- generated json ----------------------------------------------------
 json:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^5.2.1",
         "pagefind": "^1.5.2",
         "swagger-ui-express": "^5.0.1",
-        "vitepress-plugin-pagefind": "^0.4.20",
+        "vitepress-plugin-pagefind": "^0.4.22",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -21,15 +21,15 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
-      "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.2.tgz",
+      "integrity": "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -81,180 +81,180 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
-      "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.2.tgz",
+      "integrity": "sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
-      "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.2.tgz",
+      "integrity": "sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
-      "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.2.tgz",
+      "integrity": "sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
-      "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.2.tgz",
+      "integrity": "sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
-      "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.2.tgz",
+      "integrity": "sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
-      "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.2.tgz",
+      "integrity": "sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
-      "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.2.tgz",
+      "integrity": "sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
-      "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.2.tgz",
+      "integrity": "sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
-      "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.2.tgz",
+      "integrity": "sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
-      "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.2.tgz",
+      "integrity": "sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
-      "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.2.tgz",
+      "integrity": "sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
-      "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.2.tgz",
+      "integrity": "sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
-      "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.2.tgz",
+      "integrity": "sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/@iconify-json/simple-icons": {
-      "version": "1.2.88",
-      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.88.tgz",
-      "integrity": "sha512-+cvi1qCuvReL29ehi6t62L4fb7GDXe+UlGHFcsJcV7I2l9wtqn9XE2IBKcDr3CI5iGUGS5ISnXv699pSGpyx1Q==",
+      "version": "1.2.89",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.89.tgz",
+      "integrity": "sha512-hRaCY5s2G5oWAIhc4LCGYn6g6RrwLL4zhoLOT+KUO3joVCxVlZKA+839bv/47Nbe9/ZD4UA6dznZ4XPYcI53wA==",
       "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
-      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1403,13 +1403,13 @@
       }
     },
     "node_modules/@tanstack/vue-virtual": {
-      "version": "3.13.30",
-      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.30.tgz",
-      "integrity": "sha512-5IpTZf5US81z9CHaRm2imVC44WDU1V/pd8mN1OIvIerRmo6C179UN+vnzlO/dx9Fpt9X7Rjl7fyvolPhPgtfqg==",
+      "version": "3.13.31",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.31.tgz",
+      "integrity": "sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.2"
+        "@tanstack/virtual-core": "3.17.3"
       },
       "funding": {
         "type": "github",
@@ -1745,25 +1745,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
-      "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
+      "version": "5.55.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.2.tgz",
+      "integrity": "sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.21.1",
-        "@algolia/client-abtesting": "5.55.1",
-        "@algolia/client-analytics": "5.55.1",
-        "@algolia/client-common": "5.55.1",
-        "@algolia/client-insights": "5.55.1",
-        "@algolia/client-personalization": "5.55.1",
-        "@algolia/client-query-suggestions": "5.55.1",
-        "@algolia/client-search": "5.55.1",
-        "@algolia/ingestion": "1.55.1",
-        "@algolia/monitoring": "1.55.1",
-        "@algolia/recommend": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/abtesting": "1.21.2",
+        "@algolia/client-abtesting": "5.55.2",
+        "@algolia/client-analytics": "5.55.2",
+        "@algolia/client-common": "5.55.2",
+        "@algolia/client-insights": "5.55.2",
+        "@algolia/client-personalization": "5.55.2",
+        "@algolia/client-query-suggestions": "5.55.2",
+        "@algolia/client-search": "5.55.2",
+        "@algolia/ingestion": "1.55.2",
+        "@algolia/monitoring": "1.55.2",
+        "@algolia/recommend": "5.55.2",
+        "@algolia/requester-browser-xhr": "5.55.2",
+        "@algolia/requester-fetch": "5.55.2",
+        "@algolia/requester-node-http": "5.55.2"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2976,13 +2976,21 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
-      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/property-information": {
@@ -3838,15 +3846,14 @@
       }
     },
     "node_modules/vitepress-plugin-pagefind": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-pagefind/-/vitepress-plugin-pagefind-0.4.20.tgz",
-      "integrity": "sha512-O6mfkPzRV7V2igs51Qll31ptqJnHlNx9bmfo5JRsf6b4QuSVHjTDgtqM73rrCxRNeOSzFygPmJvSbmn7K4jd1A==",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-pagefind/-/vitepress-plugin-pagefind-0.4.22.tgz",
+      "integrity": "sha512-/5CUTdDPWZHqT/4jzZRXSN9XlOzg85KjlsjdE1zxqzEgKVsj1fXuRa6qcsvxKZGWlO13Eno8p7k5vyDpw4FPKA==",
       "license": "MIT",
       "dependencies": {
         "@sugarat/theme-shared": "0.0.7",
-        "@vueuse/core": "^14.1.0",
-        "javascript-stringify": "^2.1.0",
-        "vue-command-palette": "0.1.4"
+        "@vueuse/core": "^14.3.0",
+        "javascript-stringify": "^2.1.0"
       },
       "peerDependencies": {
         "pagefind": "^1.1.0",
@@ -3910,43 +3917,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-command-palette": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/vue-command-palette/-/vue-command-palette-0.1.4.tgz",
-      "integrity": "sha512-v9wGV5RG/Qe/GLLP3dJGYEvBOHQAH1kTdfzv7/uDj4v51g9uB0J3dQSaREgsrAvAT7tSj/cSbVrGpaalr8z7tg==",
-      "dependencies": {
-        "fuse.js": "^6.6.2",
-        "mitt": "^3.0.0",
-        "nanoid": "^4.0.0"
-      }
-    },
-    "node_modules/vue-command-palette/node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/vue-command-palette/node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "openapi2json": "js-yaml openapi.yaml > openapi.json",
     "generate": "npm run openapi2json",
+    "pdf": "./scripts/render-docs.sh",
+    "pdf:html": "./scripts/render-docs.sh --html",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^5.2.1",
     "pagefind": "^1.5.2",
     "swagger-ui-express": "^5.0.1",
-    "vitepress-plugin-pagefind": "^0.4.20",
+    "vitepress-plugin-pagefind": "^0.4.22",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Render openapi.yaml into a readable single-file HTML and a PDF.
+#
+#   ./scripts/render-docs.sh            # -> build/wiim-api.html and build/wiim-api.pdf
+#   ./scripts/render-docs.sh --html     # HTML only (skip PDF)
+#
+# HTML is produced with Redocly (Redoc) which gives a dense, navigable
+# reference-manual layout that reads far better than the Swagger UI.
+# The PDF is produced by printing that HTML with headless Chrome.
+#
+# Requirements:
+#   - npx (bundled with npm) — fetches @redocly/cli on first run
+#   - a Chromium/Chrome binary for the PDF step (skippable with --html)
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SPEC="openapi.yaml"
+OUT_DIR="build"
+HTML="$OUT_DIR/wiim-api.html"
+PDF="$OUT_DIR/wiim-api.pdf"
+HTML_ONLY=0
+[ "${1:-}" = "--html" ] && HTML_ONLY=1
+
+mkdir -p "$OUT_DIR"
+
+echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
+# --yes so CI/non-interactive runs don't prompt to install; version pinned-ish
+# to the 2.x line. Node < 20 prints an EBADENGINE warning but still works.
+npx --yes @redocly/cli@2 build-docs "$SPEC" -o "$HTML"
+
+if [ "$HTML_ONLY" -eq 1 ]; then
+  echo ">> HTML only requested; done: $HTML"
+  exit 0
+fi
+
+# Find a Chrome/Chromium binary for the PDF step.
+CHROME=""
+for c in google-chrome-stable google-chrome chromium chromium-browser; do
+  if command -v "$c" >/dev/null 2>&1; then CHROME="$c"; break; fi
+done
+
+if [ -z "$CHROME" ]; then
+  echo ">> No Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
+  exit 0
+fi
+
+echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
+"$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
+  --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null
+
+echo ">> Done:"
+echo "   HTML: $HTML"
+echo "   PDF:  $PDF"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -27,9 +27,12 @@ HTML_ONLY=0
 mkdir -p "$OUT_DIR"
 
 echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
-# --yes so CI/non-interactive runs don't prompt to install; version pinned-ish
-# to the 2.x line. Node < 20 prints an EBADENGINE warning but still works.
-npx --yes @redocly/cli@2 build-docs "$SPEC" -o "$HTML"
+# --yes so CI/non-interactive runs don't prompt to install. Pinned to 2.36.0,
+# the last line verified to run on Node 18 (newer 2.37+ still WORK on Node 18
+# but print a louder EBADENGINE warning). Override with REDOCLY_VERSION on a
+# machine with Node >= 20.19. The EBADENGINE warning is non-fatal.
+REDOCLY_VERSION="${REDOCLY_VERSION:-2.36.0}"
+npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML"
 
 if [ "$HTML_ONLY" -eq 1 ]; then
   echo ">> HTML only requested; done: $HTML"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -54,8 +54,23 @@ echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
 # the last line verified to run on Node 18 (newer 2.37+ still WORK on Node 18
 # but print a louder EBADENGINE warning). Override with REDOCLY_VERSION on a
 # machine with Node >= 20.19. The EBADENGINE warning is non-fatal.
+#
+# --theme.openapi.expandResponses=all is NOT cosmetic — without it, Redoc
+# renders every response body's schema behind an inactive "Schema" tab
+# (defaulting to "Example Value" instead) that only populates on a live
+# click. A static export (this HTML file, and doubly so the PDF printed
+# from it) never fires that click, so EVERY per-field description this
+# project's enrichment work adds — mode-value tables, curpos's ms-vs-µs
+# heuristic, hex/HTML decode notes, all of it — silently vanishes from
+# both outputs even though it's sitting right there in openapi.yaml.
+# Confirmed by extracting PDF text before/after: 0 matches for schema-only
+# content (e.g. "36000000", part of curpos's own description) without this
+# flag, dozens with it. Path-level `description:` prose (not inside a
+# schema) was never affected — only content living under
+# `properties.*.description` was.
 REDOCLY_VERSION="${REDOCLY_VERSION:-2.36.0}"
-npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML"
+npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML" \
+  --theme.openapi.expandResponses=all
 
 if [ "$HTML_ONLY" -eq 1 ]; then
   echo ">> HTML only requested; done: $HTML"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -2,16 +2,20 @@
 #
 # Render openapi.yaml into a readable single-file HTML and a PDF.
 #
-#   ./scripts/render-docs.sh            # -> build/wiim-api.html and build/wiim-api.pdf
-#   ./scripts/render-docs.sh --html     # HTML only (skip PDF)
+#   ./scripts/render-docs.sh                    # -> build/wiim-api.html and build/wiim-api.pdf
+#   ./scripts/render-docs.sh --html              # HTML only (skip PDF)
+#   ./scripts/render-docs.sh --engine=firefox    # force Firefox for the PDF step
+#   ./scripts/render-docs.sh --engine=chrome     # force Chrome/Chromium
 #
 # HTML is produced with Redocly (Redoc) which gives a dense, navigable
 # reference-manual layout that reads far better than the Swagger UI.
-# The PDF is produced by printing that HTML with headless Chrome.
+# The PDF is produced by printing that HTML with a headless browser: Chrome
+# or Firefox, whichever is present (Chrome preferred if both are, override
+# with --engine).
 #
 # Requirements:
 #   - npx (bundled with npm) — fetches @redocly/cli on first run
-#   - a Chromium/Chrome binary for the PDF step (skippable with --html)
+#   - a Chromium/Chrome or Firefox binary for the PDF step (skippable with --html)
 #
 set -euo pipefail
 
@@ -22,7 +26,26 @@ OUT_DIR="build"
 HTML="$OUT_DIR/wiim-api.html"
 PDF="$OUT_DIR/wiim-api.pdf"
 HTML_ONLY=0
-[ "${1:-}" = "--html" ] && HTML_ONLY=1
+ENGINE="auto"
+
+for arg in "$@"; do
+  case "$arg" in
+    --html) HTML_ONLY=1 ;;
+    --engine=*) ENGINE="${arg#--engine=}" ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$ENGINE" in
+  auto|chrome|firefox) ;;
+  *)
+    echo "Unknown --engine value: $ENGINE (expected auto|chrome|firefox)" >&2
+    exit 1
+    ;;
+esac
 
 mkdir -p "$OUT_DIR"
 
@@ -39,20 +62,74 @@ if [ "$HTML_ONLY" -eq 1 ]; then
   exit 0
 fi
 
-# Find a Chrome/Chromium binary for the PDF step.
+# Find a Chrome/Chromium binary.
 CHROME=""
 for c in google-chrome-stable google-chrome chromium chromium-browser; do
   if command -v "$c" >/dev/null 2>&1; then CHROME="$c"; break; fi
 done
 
-if [ -z "$CHROME" ]; then
-  echo ">> No Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
-  exit 0
+# Find a Firefox binary.
+FIREFOX=""
+for f in firefox firefox-esr; do
+  if command -v "$f" >/dev/null 2>&1; then FIREFOX="$f"; break; fi
+done
+
+case "$ENGINE" in
+  chrome)
+    if [ -z "$CHROME" ]; then
+      echo ">> --engine=chrome requested but no Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    FIREFOX=""
+    ;;
+  firefox)
+    if [ -z "$FIREFOX" ]; then
+      echo ">> --engine=firefox requested but no Firefox found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    CHROME=""
+    ;;
+  auto)
+    if [ -z "$CHROME" ] && [ -z "$FIREFOX" ]; then
+      echo ">> No Chrome/Chromium or Firefox found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    ;;
+esac
+
+# PDF_TIMEOUT bounds the print step so a wedged browser (seen in some
+# sandboxed/headless environments — see Firefox note below) fails fast
+# instead of hanging the whole build. Override with PDF_TIMEOUT=0 to disable.
+PDF_TIMEOUT="${PDF_TIMEOUT:-120}"
+TIMEOUT_CMD=()
+if [ "$PDF_TIMEOUT" != "0" ] && command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout "$PDF_TIMEOUT")
 fi
 
-echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
-"$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
-  --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null
+PDF_RC=0
+if [ -n "$CHROME" ]; then
+  echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
+  "${TIMEOUT_CMD[@]}" "$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
+    --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null || PDF_RC=$?
+else
+  # Firefox's --print-to-pdf refuses to run against a profile that's already
+  # locked by a running interactive instance, so it needs its own throwaway
+  # profile (-no-remote + a fresh temp dir) rather than the user's default one.
+  FF_PROFILE="$(mktemp -d)"
+  trap 'rm -rf "$FF_PROFILE"' EXIT
+  echo ">> Printing PDF with $FIREFOX ($HTML -> $PDF)"
+  "${TIMEOUT_CMD[@]}" "$FIREFOX" --headless --no-remote --profile "$FF_PROFILE" \
+    --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null || PDF_RC=$?
+fi
+
+if [ "$PDF_RC" -eq 124 ]; then
+  echo ">> PDF step timed out after ${PDF_TIMEOUT}s (PDF_TIMEOUT=0 to disable, or try --engine=chrome/firefox" >&2
+  echo "   to switch browsers). HTML is still available at: $HTML" >&2
+  exit 1
+elif [ "$PDF_RC" -ne 0 ] || [ ! -s "$PDF" ]; then
+  echo ">> PDF step produced no output (engine exited $PDF_RC). HTML is still available at: $HTML" >&2
+  exit 1
+fi
 
 echo ">> Done:"
 echo "   HTML: $HTML"

--- a/scripts/validate-spec.py
+++ b/scripts/validate-spec.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Validate openapi.yaml: parse + reject duplicate mapping keys.
+
+PyYAML's safe_load silently accepts duplicate keys (last wins), but Redoc
+and other strict tooling reject them. This loader raises on any duplicate.
+"""
+import sys
+import yaml
+
+
+class DupKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _no_duplicates(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            mark = key_node.start_mark
+            raise ValueError(
+                f"duplicate key {key!r} at line {mark.line + 1} "
+                f"column {mark.column + 1}"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+DupKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates
+)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "openapi.yaml"
+    with open(path) as f:
+        doc = yaml.load(f, Loader=DupKeyLoader)
+    n_paths = len(doc.get("paths", {}))
+    n_schemas = len(doc.get("components", {}).get("schemas", {}))
+    print(f"OK: {path} parses, no duplicate keys "
+          f"({n_paths} paths, {n_schemas} schemas)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, yaml.YAMLError) as e:
+        print(f"INVALID: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## 🧾 Summary

This adds some tooling to be able to generate a local self contained HTML file from which we then produce a PDF
which I find convenient for working locally with.

Note: The PDF generation currently uses a web  browser, and while there is support for Chrome, Chromium and Firefox, I couldn't get the latter to actually work, it constantly hangs. The default is Chrome.

This was largely written by AI under my supervision.

## 🔧 Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Chore (deps, refactor)
- [ ] Documentation

