### PR TITLE
Add tooling to generate self contained HTML and PDF docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Rendered docs (scripts/render-docs.sh)
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# WiiM HTTP API docs — build helpers.
+#
+#   make check   validate openapi.yaml (parse + duplicate-key detection)
+#   make html    render a readable single-file HTML (Redoc)
+#   make pdf      render HTML + PDF (Redoc + headless Chrome)
+#   make json     regenerate openapi.json from openapi.yaml
+#   make clean    remove build/ output
+#
+# Rendering needs npx (bundled with npm); the PDF step additionally needs a
+# Chromium/Chrome binary. Each target checks for what it needs and prints a
+# clear message if a tool is missing.
+
+SPEC := openapi.yaml
+
+.PHONY: check html pdf json clean help
+
+help:
+	@echo "targets: check | html | pdf | json | clean"
+
+# --- validation --------------------------------------------------------
+# Prefer python3; fall back to python. validate-spec.py rejects duplicate
+# mapping keys (which PyYAML otherwise silently accepts but Redoc rejects).
+check:
+	@PY=$$(command -v python3 || command -v python); \
+	if [ -z "$$PY" ]; then \
+		echo "ERROR: python3 not found (needed for 'make check')." >&2; exit 1; \
+	fi; \
+	"$$PY" scripts/validate-spec.py $(SPEC)
+
+# --- rendering ---------------------------------------------------------
+# HTML/PDF both validate first, then shell out to the render script.
+html: check
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make html'." >&2; exit 1; }
+	@./scripts/render-docs.sh --html
+
+pdf: check
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make pdf'." >&2; exit 1; }
+	@if ! command -v google-chrome-stable >/dev/null 2>&1 \
+	    && ! command -v google-chrome >/dev/null 2>&1 \
+	    && ! command -v chromium >/dev/null 2>&1 \
+	    && ! command -v chromium-browser >/dev/null 2>&1; then \
+		echo "WARNING: no Chrome/Chromium found; only HTML will be produced." >&2; \
+	fi
+	@./scripts/render-docs.sh
+
+# --- generated json ----------------------------------------------------
+json:
+	@command -v npx >/dev/null 2>&1 || { \
+		echo "ERROR: npx not found (install Node.js/npm) for 'make json'." >&2; exit 1; }
+	@npx --yes js-yaml $(SPEC) > openapi.json && echo ">> wrote openapi.json"
+
+clean:
+	@rm -rf build && echo ">> removed build/"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 # WiiM HTTP API docs — build helpers.
 #
-#   make check   validate openapi.yaml (parse + duplicate-key detection)
-#   make html    render a readable single-file HTML (Redoc)
-#   make pdf      render HTML + PDF (Redoc + headless Chrome)
-#   make json     regenerate openapi.json from openapi.yaml
-#   make clean    remove build/ output
+#   make check                 validate openapi.yaml (parse + duplicate-key detection)
+#   make html                  render a readable single-file HTML (Redoc)
+#   make pdf                   render HTML + PDF (Redoc + headless Chrome/Firefox)
+#   make pdf ENGINE=firefox    force Firefox for the PDF step (default: auto)
+#   make json                  regenerate openapi.json from openapi.yaml
+#   make clean                 remove build/ output
 #
 # Rendering needs npx (bundled with npm); the PDF step additionally needs a
-# Chromium/Chrome binary. Each target checks for what it needs and prints a
-# clear message if a tool is missing.
+# Chromium/Chrome or Firefox binary. Each target checks for what it needs and
+# prints a clear message if a tool is missing.
 
 SPEC := openapi.yaml
+ENGINE := auto
 
 .PHONY: check html pdf json clean help
 
@@ -40,10 +42,12 @@ pdf: check
 	@if ! command -v google-chrome-stable >/dev/null 2>&1 \
 	    && ! command -v google-chrome >/dev/null 2>&1 \
 	    && ! command -v chromium >/dev/null 2>&1 \
-	    && ! command -v chromium-browser >/dev/null 2>&1; then \
-		echo "WARNING: no Chrome/Chromium found; only HTML will be produced." >&2; \
+	    && ! command -v chromium-browser >/dev/null 2>&1 \
+	    && ! command -v firefox >/dev/null 2>&1 \
+	    && ! command -v firefox-esr >/dev/null 2>&1; then \
+		echo "WARNING: no Chrome/Chromium/Firefox found; only HTML will be produced." >&2; \
 	fi
-	@./scripts/render-docs.sh
+	@./scripts/render-docs.sh --engine=$(ENGINE)
 
 # --- generated json ----------------------------------------------------
 json:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "openapi2json": "js-yaml openapi.yaml > openapi.json",
     "generate": "npm run openapi2json",
+    "pdf": "./scripts/render-docs.sh",
+    "pdf:html": "./scripts/render-docs.sh --html",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Render openapi.yaml into a readable single-file HTML and a PDF.
+#
+#   ./scripts/render-docs.sh            # -> build/wiim-api.html and build/wiim-api.pdf
+#   ./scripts/render-docs.sh --html     # HTML only (skip PDF)
+#
+# HTML is produced with Redocly (Redoc) which gives a dense, navigable
+# reference-manual layout that reads far better than the Swagger UI.
+# The PDF is produced by printing that HTML with headless Chrome.
+#
+# Requirements:
+#   - npx (bundled with npm) — fetches @redocly/cli on first run
+#   - a Chromium/Chrome binary for the PDF step (skippable with --html)
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SPEC="openapi.yaml"
+OUT_DIR="build"
+HTML="$OUT_DIR/wiim-api.html"
+PDF="$OUT_DIR/wiim-api.pdf"
+HTML_ONLY=0
+[ "${1:-}" = "--html" ] && HTML_ONLY=1
+
+mkdir -p "$OUT_DIR"
+
+echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
+# --yes so CI/non-interactive runs don't prompt to install; version pinned-ish
+# to the 2.x line. Node < 20 prints an EBADENGINE warning but still works.
+npx --yes @redocly/cli@2 build-docs "$SPEC" -o "$HTML"
+
+if [ "$HTML_ONLY" -eq 1 ]; then
+  echo ">> HTML only requested; done: $HTML"
+  exit 0
+fi
+
+# Find a Chrome/Chromium binary for the PDF step.
+CHROME=""
+for c in google-chrome-stable google-chrome chromium chromium-browser; do
+  if command -v "$c" >/dev/null 2>&1; then CHROME="$c"; break; fi
+done
+
+if [ -z "$CHROME" ]; then
+  echo ">> No Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
+  exit 0
+fi
+
+echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
+"$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
+  --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null
+
+echo ">> Done:"
+echo "   HTML: $HTML"
+echo "   PDF:  $PDF"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -27,9 +27,12 @@ HTML_ONLY=0
 mkdir -p "$OUT_DIR"
 
 echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
-# --yes so CI/non-interactive runs don't prompt to install; version pinned-ish
-# to the 2.x line. Node < 20 prints an EBADENGINE warning but still works.
-npx --yes @redocly/cli@2 build-docs "$SPEC" -o "$HTML"
+# --yes so CI/non-interactive runs don't prompt to install. Pinned to 2.36.0,
+# the last line verified to run on Node 18 (newer 2.37+ still WORK on Node 18
+# but print a louder EBADENGINE warning). Override with REDOCLY_VERSION on a
+# machine with Node >= 20.19. The EBADENGINE warning is non-fatal.
+REDOCLY_VERSION="${REDOCLY_VERSION:-2.36.0}"
+npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML"
 
 if [ "$HTML_ONLY" -eq 1 ]; then
   echo ">> HTML only requested; done: $HTML"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -54,8 +54,23 @@ echo ">> Building HTML with Redocly ($SPEC -> $HTML)"
 # the last line verified to run on Node 18 (newer 2.37+ still WORK on Node 18
 # but print a louder EBADENGINE warning). Override with REDOCLY_VERSION on a
 # machine with Node >= 20.19. The EBADENGINE warning is non-fatal.
+#
+# --theme.openapi.expandResponses=all is NOT cosmetic — without it, Redoc
+# renders every response body's schema behind an inactive "Schema" tab
+# (defaulting to "Example Value" instead) that only populates on a live
+# click. A static export (this HTML file, and doubly so the PDF printed
+# from it) never fires that click, so EVERY per-field description this
+# project's enrichment work adds — mode-value tables, curpos's ms-vs-µs
+# heuristic, hex/HTML decode notes, all of it — silently vanishes from
+# both outputs even though it's sitting right there in openapi.yaml.
+# Confirmed by extracting PDF text before/after: 0 matches for schema-only
+# content (e.g. "36000000", part of curpos's own description) without this
+# flag, dozens with it. Path-level `description:` prose (not inside a
+# schema) was never affected — only content living under
+# `properties.*.description` was.
 REDOCLY_VERSION="${REDOCLY_VERSION:-2.36.0}"
-npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML"
+npx --yes "@redocly/cli@${REDOCLY_VERSION}" build-docs "$SPEC" -o "$HTML" \
+  --theme.openapi.expandResponses=all
 
 if [ "$HTML_ONLY" -eq 1 ]; then
   echo ">> HTML only requested; done: $HTML"

--- a/scripts/render-docs.sh
+++ b/scripts/render-docs.sh
@@ -2,16 +2,20 @@
 #
 # Render openapi.yaml into a readable single-file HTML and a PDF.
 #
-#   ./scripts/render-docs.sh            # -> build/wiim-api.html and build/wiim-api.pdf
-#   ./scripts/render-docs.sh --html     # HTML only (skip PDF)
+#   ./scripts/render-docs.sh                    # -> build/wiim-api.html and build/wiim-api.pdf
+#   ./scripts/render-docs.sh --html              # HTML only (skip PDF)
+#   ./scripts/render-docs.sh --engine=firefox    # force Firefox for the PDF step
+#   ./scripts/render-docs.sh --engine=chrome     # force Chrome/Chromium
 #
 # HTML is produced with Redocly (Redoc) which gives a dense, navigable
 # reference-manual layout that reads far better than the Swagger UI.
-# The PDF is produced by printing that HTML with headless Chrome.
+# The PDF is produced by printing that HTML with a headless browser: Chrome
+# or Firefox, whichever is present (Chrome preferred if both are, override
+# with --engine).
 #
 # Requirements:
 #   - npx (bundled with npm) — fetches @redocly/cli on first run
-#   - a Chromium/Chrome binary for the PDF step (skippable with --html)
+#   - a Chromium/Chrome or Firefox binary for the PDF step (skippable with --html)
 #
 set -euo pipefail
 
@@ -22,7 +26,26 @@ OUT_DIR="build"
 HTML="$OUT_DIR/wiim-api.html"
 PDF="$OUT_DIR/wiim-api.pdf"
 HTML_ONLY=0
-[ "${1:-}" = "--html" ] && HTML_ONLY=1
+ENGINE="auto"
+
+for arg in "$@"; do
+  case "$arg" in
+    --html) HTML_ONLY=1 ;;
+    --engine=*) ENGINE="${arg#--engine=}" ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$ENGINE" in
+  auto|chrome|firefox) ;;
+  *)
+    echo "Unknown --engine value: $ENGINE (expected auto|chrome|firefox)" >&2
+    exit 1
+    ;;
+esac
 
 mkdir -p "$OUT_DIR"
 
@@ -39,20 +62,74 @@ if [ "$HTML_ONLY" -eq 1 ]; then
   exit 0
 fi
 
-# Find a Chrome/Chromium binary for the PDF step.
+# Find a Chrome/Chromium binary.
 CHROME=""
 for c in google-chrome-stable google-chrome chromium chromium-browser; do
   if command -v "$c" >/dev/null 2>&1; then CHROME="$c"; break; fi
 done
 
-if [ -z "$CHROME" ]; then
-  echo ">> No Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
-  exit 0
+# Find a Firefox binary.
+FIREFOX=""
+for f in firefox firefox-esr; do
+  if command -v "$f" >/dev/null 2>&1; then FIREFOX="$f"; break; fi
+done
+
+case "$ENGINE" in
+  chrome)
+    if [ -z "$CHROME" ]; then
+      echo ">> --engine=chrome requested but no Chrome/Chromium found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    FIREFOX=""
+    ;;
+  firefox)
+    if [ -z "$FIREFOX" ]; then
+      echo ">> --engine=firefox requested but no Firefox found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    CHROME=""
+    ;;
+  auto)
+    if [ -z "$CHROME" ] && [ -z "$FIREFOX" ]; then
+      echo ">> No Chrome/Chromium or Firefox found; skipping PDF. HTML is at: $HTML" >&2
+      exit 0
+    fi
+    ;;
+esac
+
+# PDF_TIMEOUT bounds the print step so a wedged browser (seen in some
+# sandboxed/headless environments — see Firefox note below) fails fast
+# instead of hanging the whole build. Override with PDF_TIMEOUT=0 to disable.
+PDF_TIMEOUT="${PDF_TIMEOUT:-120}"
+TIMEOUT_CMD=()
+if [ "$PDF_TIMEOUT" != "0" ] && command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout "$PDF_TIMEOUT")
 fi
 
-echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
-"$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
-  --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null
+PDF_RC=0
+if [ -n "$CHROME" ]; then
+  echo ">> Printing PDF with $CHROME ($HTML -> $PDF)"
+  "${TIMEOUT_CMD[@]}" "$CHROME" --headless --no-sandbox --disable-gpu --no-pdf-header-footer \
+    --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null || PDF_RC=$?
+else
+  # Firefox's --print-to-pdf refuses to run against a profile that's already
+  # locked by a running interactive instance, so it needs its own throwaway
+  # profile (-no-remote + a fresh temp dir) rather than the user's default one.
+  FF_PROFILE="$(mktemp -d)"
+  trap 'rm -rf "$FF_PROFILE"' EXIT
+  echo ">> Printing PDF with $FIREFOX ($HTML -> $PDF)"
+  "${TIMEOUT_CMD[@]}" "$FIREFOX" --headless --no-remote --profile "$FF_PROFILE" \
+    --print-to-pdf="$PDF" "file://$(pwd)/$HTML" 2>/dev/null || PDF_RC=$?
+fi
+
+if [ "$PDF_RC" -eq 124 ]; then
+  echo ">> PDF step timed out after ${PDF_TIMEOUT}s (PDF_TIMEOUT=0 to disable, or try --engine=chrome/firefox" >&2
+  echo "   to switch browsers). HTML is still available at: $HTML" >&2
+  exit 1
+elif [ "$PDF_RC" -ne 0 ] || [ ! -s "$PDF" ]; then
+  echo ">> PDF step produced no output (engine exited $PDF_RC). HTML is still available at: $HTML" >&2
+  exit 1
+fi
 
 echo ">> Done:"
 echo "   HTML: $HTML"

--- a/scripts/validate-spec.py
+++ b/scripts/validate-spec.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Validate openapi.yaml: parse + reject duplicate mapping keys.
+
+PyYAML's safe_load silently accepts duplicate keys (last wins), but Redoc
+and other strict tooling reject them. This loader raises on any duplicate.
+"""
+import sys
+import yaml
+
+
+class DupKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _no_duplicates(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            mark = key_node.start_mark
+            raise ValueError(
+                f"duplicate key {key!r} at line {mark.line + 1} "
+                f"column {mark.column + 1}"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+DupKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates
+)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "openapi.yaml"
+    with open(path) as f:
+        doc = yaml.load(f, Loader=DupKeyLoader)
+    n_paths = len(doc.get("paths", {}))
+    n_schemas = len(doc.get("components", {}).get("schemas", {}))
+    print(f"OK: {path} parses, no duplicate keys "
+          f"({n_paths} paths, {n_schemas} schemas)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, yaml.YAMLError) as e:
+        print(f"INVALID: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## 🧾 Summary

This adds some tooling to be able to generate a local self contained HTML file from which we then produce a PDF
which I find convenient for working locally with.

Note: The PDF generation currently uses a web browser, and while there is support for Chrome, Chromium and Firefox, I couldn't get the latter to actually work, it constantly hangs. The default is Chrome.

This was largely written by AI under my supervision.


## 🔧 Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Chore (deps, refactor)
- [ ] Documentation